### PR TITLE
Iterating over multi-page job results failed

### DIFF
--- a/pan_cortex_data_lake/query.py
+++ b/pan_cortex_data_lake/query.py
@@ -242,9 +242,9 @@ class QueryService(object):
             if not r.ok:
                 raise HTTPError("%s" % r.text)
             if r.json()["state"] == "DONE":
-                scroll_token = r.json()["page"].get("scrollToken")
-                if scroll_token is not None:
-                    params["pageCursor"] = scroll_token
+                page_cursor = r.json()["page"].get("pageCursor")
+                if page_cursor is not None:
+                    params["pageCursor"] = page_cursor
                     yield r
                 else:
                     yield r


### PR DESCRIPTION
scrollToken -> pageCursor

## Description

<!--- Describe your changes in detail -->
The job result iterator used the (probably deprecated) response's `page.scrollToken` value. This PR changes that according to the current docs (and prod implementation).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Iterating over multiple pages (i.e. multiple `/query/v2/jobResults/*` requests) does not work.

## How Has This Been Tested?

Just locally, no idea if the test suite tests this, probably CI finds out.

## Types of changes

<!--- What types of changes does your code introduce? -->

<!--- Remove any that don't apply: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
