### PR TITLE
Alpha10

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 2.0.0-alpha10 (2020-04-09)
+
+-   Refactor how and where credentials are applied to request headers (#151)
+
 ## 2.0.0-alpha9 (2020-04-04)
 
 -   Now checking if static `access_token` exists before attempting a developer token refresh (#147)

--- a/pan_cortex_data_lake/__init__.py
+++ b/pan_cortex_data_lake/__init__.py
@@ -3,7 +3,7 @@
 """Main package for cortex."""
 
 __author__ = "Palo Alto Networks"
-__version__ = "2.0.0-a9"
+__version__ = "2.0.0-a10"
 
 from .exceptions import (  # noqa: F401
     CortexError,

--- a/pan_cortex_data_lake/httpclient.py
+++ b/pan_cortex_data_lake/httpclient.py
@@ -45,7 +45,7 @@ class HTTPClient(object):
         granular performance and reliability tuning.
 
         Parameters:
-            auto_refresh (bool): Perform token refresh following HTTP 401 response from server. Defaults to ``True``.
+            auto_refresh (bool): Perform token refresh prior to request if ``access_token`` is ``None`` or expired. Defaults to ``True``.
             auto_retry (bool): Retry last failed HTTP request following a token refresh. Defaults to ``True``.
             credentials (Credentials): :class:`~pan_cortex_data_lake.credentials.Credentials` object. Defaults to ``None``.
             enforce_json (bool): Require properly-formatted JSON or raise :exc:`~pan_cortex_data_lake.exceptions.CortecError`. Defaults to ``False``.

--- a/pan_cortex_data_lake/httpclient.py
+++ b/pan_cortex_data_lake/httpclient.py
@@ -94,13 +94,6 @@ class HTTPClient(object):
             if len(kwargs) > 0:  # Handle invalid kwargs
                 raise UnexpectedKwargsError(kwargs)
 
-            if self.credentials:
-                logger.debug("Applying session-level credentials")
-                self._apply_credentials(
-                    auto_refresh=self.auto_refresh,
-                    credentials=self.credentials,
-                    headers=self.session.headers,
-                )
             self.stats = ApiStats({"transactions": 0})
 
     def __repr__(self):
@@ -139,7 +132,7 @@ class HTTPClient(object):
             if token is None:
                 token = credentials.refresh(access_token=None, timeout=10)
                 logger.debug("Token refreshed due to 'None' condition")
-            elif credentials.jwt_is_expired():
+            elif credentials.jwt_is_expired(token):
                 token = credentials.refresh(timeout=10)
                 logger.debug("Token refreshed due to 'expired' condition")
         headers.update({"Authorization": "Bearer {}".format(token)})
@@ -220,7 +213,7 @@ class HTTPClient(object):
 
         # Non-Requests key-word arguments
         auto_refresh = kwargs.pop("auto_refresh", self.auto_refresh)
-        credentials = kwargs.pop("credentials", None)
+        credentials = kwargs.pop("credentials", self.credentials)
         endpoint = kwargs.pop("endpoint", "")  # default to empty endpoint
         enforce_json = kwargs.pop("enforce_json", self.enforce_json)
         raise_for_status = kwargs.pop("raise_for_status", self.raise_for_status)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0a9
+current_version = 2.0.0a10
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ test_requirements = ["pytest"]
 
 setup(
     name="pan-cortex-data-lake",
-    version="2.0.0-a9",
+    version="2.0.0-a10",
     description="Python idiomatic SDK for Cortex™ Data Lake.",
     long_description=readme + "\n\n" + history,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactored how credentials are applied to requests to address bug #151. It was observed that `auto_refresh` was not being honored due to a regression bug introduced in #140  (see below).

https://github.com/PaloAltoNetworks/pan-cortex-data-lake-python/pull/140/files#diff-0d2109dfe6920fb8c5b42a91db1c1ff2R223

The regression fix (#140) was intended to prevent authorization headers from being updated more than is necessary: once for when the `HTTPClient` object is created and another time each time the `request()` method is called. Instead, it was determined that credentials can and should only be applied at the `request()` layer. Furthermore, the `request()` kwarg for `credentials` was changed back to check for both method-level credentials and credentials passed via the `HTTPClient` session.

## Motivation and Context

* `auto_refresh` is a key feature that was found to not be functioning as expected
* Credentials should only be applied as often as needed and should be supported at the session and method levels.

## How Has This Been Tested?

* python test script

## Screenshots (if appropriate)

<!--- Drag any screenshots here -->

## Types of changes

<!--- What types of changes does your code introduce? -->

<!--- Remove any that don't apply: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
