### PR TITLE
Allow non-200 HTTP status in iter_job_results()

### DIFF
--- a/pan_cortex_data_lake/query.py
+++ b/pan_cortex_data_lake/query.py
@@ -235,8 +235,6 @@ class QueryService(object):
             r = self.get_job_results(
                 job_id=job_id, params=params, enforce_json=enforce_json, **kwargs
             )
-            if not r.ok:
-                raise HTTPError("%s" % r.text)
             r_json = r.json()
             if r_json["state"] == "DONE":
                 page_cursor = r_json["page"].get("pageCursor")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow non-200 responses in `iter_job_results()` method so that errors may be returned to client.

## Motivation and Context

Error responses should be returned to client when using `iter_job_results()`. Currently, errors are masked due to the exception raised when a non-200 status is returned.

## How Has This Been Tested?

Tested using scripts and CI/CD

## Screenshots (if appropriate)

<!--- Drag any screenshots here -->

## Types of changes

<!--- What types of changes does your code introduce? -->

<!--- Remove any that don't apply: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
