### PR TITLE
Continue if state is RUNNING or PENDING in iter_job_results(), fixes …

### DIFF
--- a/pan_cortex_data_lake/query.py
+++ b/pan_cortex_data_lake/query.py
@@ -246,8 +246,8 @@ class QueryService(object):
                     yield r
                     break
             elif r_json["state"] in ("RUNNING", "PENDING"):
-                yield r
                 time.sleep(1)
+                continue
             elif r_json["state"] == "FAILED":
                 yield r
                 break


### PR DESCRIPTION
…#162

<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactored `iter_job_results()` to `continue` if state is "PENDING" or "RUNNING."

## Motivation and Context

Addresses issue #162 

## How Has This Been Tested?

Scripts and CI/CD

## Screenshots (if appropriate)

<!--- Drag any screenshots here -->

## Types of changes

<!--- What types of changes does your code introduce? -->

<!--- Remove any that don't apply: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
